### PR TITLE
Persist DisableStretch in embedded preset/project data

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -92,6 +92,19 @@ impl Default for GyroflowPluginBase {
 }
 
 impl GyroflowPluginBase {
+    /// If `disable_stretch` is true, inject a `plugin_disable_stretch` flag into gyroflow JSON data
+    /// so that the setting persists when the data is embedded in a preset or project.
+    fn maybe_inject_disable_stretch(data: &str, disable_stretch: bool) -> String {
+        if !disable_stretch { return data.to_string(); }
+        if let Ok(mut json) = serde_json::from_str::<serde_json::Value>(data) {
+            json["plugin_disable_stretch"] = serde_json::Value::Bool(true);
+            if let Ok(s) = serde_json::to_string(&json) {
+                return s;
+            }
+        }
+        data.to_string()
+    }
+
     pub fn initialize_gpu_context(&mut self) {
         log::info!("GyroflowPluginBase::initialize_gpu_context");
         if !self.context_initialized {
@@ -522,7 +535,7 @@ impl GyroflowPluginBaseInstance {
     }
 
     pub fn stab_manager(&mut self, params: &mut dyn GyroflowPluginParams, manager_cache: &Mutex<LruCache<String, Arc<StabilizationManager>>>, out_size: (usize, usize), open_gyroflow_if_no_data: bool) -> PluginResult<Arc<StabilizationManager>> {
-        let disable_stretch = params.get_bool(Params::DisableStretch)?;
+        let mut disable_stretch = params.get_bool(Params::DisableStretch)?;
 
         let instance_id = params.get_string(Params::InstanceId)?;
         let path = params.get_string(Params::ProjectPath)?;
@@ -606,6 +619,7 @@ impl GyroflowPluginBaseInstance {
                         }
                         if params.get_bool(Params::IncludeProjectData)? {
                             if let Ok(data) = stab.export_gyroflow_data(gyroflow_core::GyroflowProjectType::WithGyroData, "{}", None) {
+                                let data = Self::maybe_inject_disable_stretch(&data, disable_stretch);
                                 params.set_string(Params::ProjectData, &data)?;
                             }
                         }
@@ -762,6 +776,23 @@ impl GyroflowPluginBaseInstance {
 
             self.update_loaded_state(params, loaded);
 
+            // Check if loaded preset/project data contains the plugin_disable_stretch flag
+            if !disable_stretch {
+                for param_id in [Params::EmbeddedPreset, Params::ProjectData] {
+                    if let Ok(d) = params.get_string(param_id) {
+                        if !d.is_empty() {
+                            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&d) {
+                                if v.get("plugin_disable_stretch").and_then(|v| v.as_bool()).unwrap_or(false) {
+                                    disable_stretch = true;
+                                    let _ = params.set_bool(Params::DisableStretch, true);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             if disable_stretch {
                 stab.disable_lens_stretch(self.anamorphic_adjust_size);
             }
@@ -894,14 +925,17 @@ impl GyroflowPluginBaseInstance {
         }
         if param == Params::IncludeProjectData {
             let path = params.get_string(Params::ProjectPath)?;
+            let ds = params.get_bool(Params::DisableStretch).unwrap_or(false);
             if params.get_bool(Params::IncludeProjectData).unwrap_or_default() {
                 if path.ends_with(".gyroflow") {
                     if let Ok(data) = std::fs::read_to_string(&path) {
                         if StabilizationManager::project_has_motion_data(data.as_bytes()) {
+                            let data = Self::maybe_inject_disable_stretch(&data, ds);
                             params.set_string(Params::ProjectData, &data)?;
                         } else {
                             if let Some((_, stab)) = self.managers.peek_lru() {
                                 if let Ok(data) = stab.export_gyroflow_data(gyroflow_core::GyroflowProjectType::WithGyroData, "{}", None) {
+                                    let data = Self::maybe_inject_disable_stretch(&data, ds);
                                     params.set_string(Params::ProjectData, &data)?;
                                 }
                             }
@@ -912,6 +946,7 @@ impl GyroflowPluginBaseInstance {
                 } else {
                     if let Some((_, stab)) = self.managers.peek_lru() {
                         if let Ok(data) = stab.export_gyroflow_data(gyroflow_core::GyroflowProjectType::WithGyroData, "{}", None) {
+                            let data = Self::maybe_inject_disable_stretch(&data, ds);
                             params.set_string(Params::ProjectData, &data)?;
                         }
                     }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -776,9 +776,9 @@ impl GyroflowPluginBaseInstance {
 
             self.update_loaded_state(params, loaded);
 
-            // Check if loaded preset/project data contains the plugin_disable_stretch flag
+            // Check if loaded preset/project/lens data contains the plugin_disable_stretch flag
             if !disable_stretch {
-                for param_id in [Params::EmbeddedPreset, Params::ProjectData] {
+                for param_id in [Params::EmbeddedLensProfile, Params::EmbeddedPreset, Params::ProjectData] {
                     if let Ok(d) = params.get_string(param_id) {
                         if !d.is_empty() {
                             if let Ok(v) = serde_json::from_str::<serde_json::Value>(&d) {


### PR DESCRIPTION
## Summary

- When "Disable Gyroflow's stretch" is checked and project data is saved (via "Embed .gyroflow data in plugin" or preset export), a `plugin_disable_stretch: true` flag is injected into the gyroflow JSON
- On load, the flag is detected from `EmbeddedPreset` or `ProjectData` and `DisableStretch` is automatically enabled
- No changes to gyroflow-core required — the flag is a top-level JSON field that the core ignores

## Motivation

When using anamorphic lenses in DaVinci Resolve (or any NLE that handles desqueeze via Pixel Aspect Ratio), users must manually check "Disable Gyroflow's stretch" on every clip. This setting cannot currently be saved in presets because it's a plugin-level parameter that doesn't persist in the gyroflow project data.

This change lets the setting travel with embedded project data, so applying a preset to new clips automatically carries the DisableStretch state.

## Changes

`common/src/lib.rs`:
- Add `maybe_inject_disable_stretch()` helper that injects the flag into JSON when DisableStretch is enabled
- Call it at all project data export/save points
- On load, check `EmbeddedPreset` and `ProjectData` for the flag before applying `disable_lens_stretch()`
- Make `disable_stretch` mutable so it can be updated from the loaded data

## Test plan

- [ ] Load a .gyroflow project with an anamorphic lens profile (input_horizontal_stretch != 1.0)
- [ ] Check "Disable Gyroflow's stretch" and "Embed .gyroflow data in plugin"
- [ ] Copy the effect to another clip — DisableStretch should auto-enable
- [ ] Save and reopen the project — DisableStretch should persist
- [ ] Without the flag in the data, behavior is unchanged (DisableStretch defaults to false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)