### PR TITLE
Detect plugin_disable_stretch in auto-loaded default.gyroflow

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -778,16 +778,37 @@ impl GyroflowPluginBaseInstance {
 
             // Check if loaded preset/project/lens data contains the plugin_disable_stretch flag
             if !disable_stretch {
+                let has_flag = |d: &str| -> bool {
+                    serde_json::from_str::<serde_json::Value>(d).ok()
+                        .and_then(|v| v.get("plugin_disable_stretch").and_then(|v| v.as_bool()))
+                        .unwrap_or(false)
+                };
                 for param_id in [Params::EmbeddedLensProfile, Params::EmbeddedPreset, Params::ProjectData] {
                     if let Ok(d) = params.get_string(param_id) {
-                        if !d.is_empty() {
-                            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&d) {
-                                if v.get("plugin_disable_stretch").and_then(|v| v.as_bool()).unwrap_or(false) {
-                                    disable_stretch = true;
-                                    let _ = params.set_bool(Params::DisableStretch, true);
-                                    break;
-                                }
+                        if !d.is_empty() && has_flag(&d) {
+                            disable_stretch = true;
+                            let _ = params.set_bool(Params::DisableStretch, true);
+                            break;
+                        }
+                    }
+                }
+                // Also check default.gyroflow, which gyroflow-core auto-loads inside
+                // load_video_file but never exposes through the plugin's Embedded* params.
+                // Paths and fallback order match `StabilizationManager::load_video_file`.
+                if !disable_stretch {
+                    let paths = [
+                        gyroflow_core::settings::data_dir().join("lens_profiles").join("default.gyroflow"),
+                        gyroflow_core::lens_profile_database::LensProfileDatabase::get_path().join("default.gyroflow"),
+                    ];
+                    for path in &paths {
+                        if let Ok(d) = std::fs::read_to_string(path) {
+                            if has_flag(&d) {
+                                disable_stretch = true;
+                                let _ = params.set_bool(Params::DisableStretch, true);
+                                break;
                             }
+                            // Matches core: stop after the first existing path (settings preferred).
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Follow-up to #51. Extend `plugin_disable_stretch` detection to the `default.gyroflow` auto-load path.

## Bug

#51 handled the flag for presets loaded via the plugin's "Load Lens" button (flowing through `EmbeddedLensProfile` / `EmbeddedPreset` / `ProjectData` params). But when a user saves their preset as `default.gyroflow`, gyroflow-core auto-loads it inside `StabilizationManager::load_video_file` via `import_gyroflow_file` — that path reads the file directly and applies its contents to stabilizer state without touching any plugin params.

Result: the preset name shows correctly in the plugin UI, but DisableStretch never activates.

## Fix

After the existing `Embedded*` params check, also read `default.gyroflow` from the same two paths core checks (`settings_path` then `local_path`, settings preferred). If the flag is found, enable DisableStretch like the other sources do. The JSON flag check is factored into a `has_flag` closure to avoid duplication.

No core changes required — the plugin reads the file using the already-public `gyroflow_core::settings::data_dir()` and `gyroflow_core::lens_profile_database::LensProfileDatabase::get_path()`.

## Test plan

- [ ] Gyroflow app: set up stabilization on an anamorphic clip, export preset with "Disable Gyroflow's stretch" checked, save as `default.gyroflow` in the lens profile directory
- [ ] Resolve: apply Gyroflow OFX plugin to a new anamorphic clip
- [ ] Verify the preset name appears in the plugin UI AND "Disable Gyroflow's stretch" is automatically enabled
- [ ] Verify unchecking DisableStretch via the plugin UI works (matches existing behavior with `Embedded*` sources)