### PR TITLE
Fix Premiere subclip stabilization by accounting for Media_ContentStart

### DIFF
--- a/adobe/src/premiere.rs
+++ b/adobe/src/premiere.rs
@@ -150,6 +150,17 @@ impl pr::GpuFilter for PremiereGPU {
                 let key = format!("{path}{disable_stretch}{instance_id}");
                 // log::info!("PremiereGPU::render! {pixel_format:?} in: {in_frame_data:?}, out: {out_frame_data:?}, stride: {in_stride}/{out_stride}, bounds: {in_bounds:?}/{out_bounds:?}, disable_stretch: {disable_stretch:?} path: {} instance_id: {instance_id:?} | time: {}", path, render_params.clip_time());
 
+                // A bin subclip has its own time domain: clip_time is relative to the subclip's
+                // start, not to the start of the master media. Media_ContentStart reports where
+                // that domain begins within the master file, and is absent (0) for a plain
+                // master clip, whose clip_time is already master-relative. Gyro data is anchored
+                // to master-file time, so without this every subclip frame gets the sample from
+                // Media_ContentStart earlier.
+                let media_content_start = match filter.video_segment_suite.node_property(media_node.1, pr::Property::Media_ContentStart) {
+                    Ok(pr::PropertyData::Time(start)) => start as i64,
+                    _ => 0
+                };
+
                 let mut trim_range = None;
                 if let Ok(pr::PropertyData::Int64(start)) = filter.video_segment_suite.node_property(media_node.1, pr::Property::Media_InPointMediaTimeAsTicks) {
                     if let Ok(pr::PropertyData::Int64(end)) = filter.video_segment_suite.node_property(media_node.1, pr::Property::Media_OutPointMediaTimeAsTicks) {
@@ -184,7 +195,7 @@ impl pr::GpuFilter for PremiereGPU {
                     let fps_ticks = if fps_ticks == 0 { ticks_per_sec / fps } else { fps_ticks as f64 };
 
                     // round the timestamp_us according to the fps, so it's never between frames and always points to a valid frame timestamp
-                    let frame = render_params.clip_time() as f64 / fps_ticks;
+                    let frame = (render_params.clip_time() + media_content_start) as f64 / fps_ticks;
                     let frame = if frame.fract() > 0.999 { frame.ceil() } else { frame.floor() };
                     let timestamp_us = (frame * (1_000_000.0 / fps)).round() as i64;
 


### PR DESCRIPTION
## Problem

Applying the Gyroflow effect to a **Premiere bin subclip** produces actively wrong stabilization (shaky, not merely unstabilized), while the same media as a full master clip works correctly. This is the Adobe/Premiere half of #59, and the same bug class as #25 (OFX/Resolve).

Root cause: a bin subclip has its own time domain. `render_params.clip_time()` is relative to the **subclip's** start, whereas gyro data is anchored to **master-file** time. `adobe/src/premiere.rs` derives the timestamp from `clip_time()` alone:

```rust
let frame = render_params.clip_time() as f64 / fps_ticks;
```

so every frame of a subclip is fed the gyro sample from `Media_ContentStart` earlier — a wrong rotation per frame, which is why it reads as shaky rather than unstabilized.

## The signal: `Media_ContentStart`

Dumping `iterate_node_properties` on the media node (the debug block already present in `premiere.rs`) for a subclip vs. an identically-sourced master clip, at 254016000000 ticks/sec:

| Property | Master clip | Subclip |
|---|---|---|
| `Media_ContentStart` | *absent* | `4592609280000` (18.08 s) |
| `Media_ContentEnd` | *absent* | `6457086720000` (25.42 s) |
| `Media_InPointMediaTimeAsTicks` | `3068513280000` (12.08 s) | `4592609280000` (18.08 s) |
| `Media_StartTimecodeOffset` | `7355033280000000` | `7355033280000000` (identical) |

Two things follow:

1. The subclip's `Media_InPointMediaTimeAsTicks` **equals** its `Media_ContentStart`, so Premiere reports it in master-file time — the offset is reachable.
2. `Media_ContentStart` is **absent on a plain master clip**, which is what makes the correction safe: it defaults to 0 and is a no-op there.

Note `Media_StartTimecodeOffset` is identical on both and is *not* the subclip offset — media with a non-zero start timecode does not spuriously acquire a `ContentStart`.

The consistent model: **`clip_time` is node-local time measured from the media node's content origin, and `Media_ContentStart` is where that origin sits in the master file.** A master clip's origin is 0, so its `clip_time` is already master-relative — which is why trimming a master clip has always worked. This also explains why `Media_ContentStart` is the right term rather than `Media_InPointMediaTimeAsTicks`: for a subclip trimmed further on the timeline, `In` moves but the origin doesn't, and `clip_time + ContentStart == In` still holds.

## The fix

```rust
let media_content_start = match filter.video_segment_suite.node_property(media_node.1, pr::Property::Media_ContentStart) {
    Ok(pr::PropertyData::Time(start)) => start as i64,
    _ => 0
};
...
let frame = (render_params.clip_time() + media_content_start) as f64 / fps_ticks;
```

Unlike the OFX fix in 3fd21d6, there's no Premiere equivalent of Resolve 20's `kOfxImageEffectPropSrcFrame`, so the offset has to come from the segment properties instead.

## Verification

**Environment:** Premiere Pro **26.2.0** (build 26.2.0.65), Windows 11, RTX 5070 Ti. Exercised on **both** GPU backends — Mercury Playback Engine GPU Acceleration (**CUDA**) and (**OpenCL**) — since `premiere.rs::render` dispatches those into different `BufferSource` variants, though the timestamp arithmetic is upstream of that branch.

**Media:** Fujifilm X-H2S `.mov`, 50 fps, 3840x2160, gyro data embedded in the `.gyroflow` project. Primary test clip has a subclip starting **18.08 s** into the master file (`Media_ContentStart = 4592609280000`, extents 18.08 – 25.42 s). Additional clips exercised incidentally during real editing across 5 different source files (`XH2S4230`, `XH2S4356`, `XH2S4383`, `XH2S4388`, `XH2S4394`), all with proxies attached.

**Method:** the plugin was instrumented to log `clip_time`, `Media_ContentStart`, the resulting `media_time`/`timestamp_us`, and a full `iterate_node_properties` dump per effect instance. Roughly 6,700 instrumented renders across the session (~6,200 master-clip, ~450 subclip). Each scenario was confirmed both by the logged numbers and by eye in the program monitor.

**Headline before/after** (instrumented `timestamp_us`):

- **Subclip**: rendered window moved from `0 – 5.84 s` — wrong by 18.08 s on *every* frame — to `18.08 – 23.92 s`, inside the subclip's true `18.08 – 25.42 s` extents.
- **Master clip**: `media_time == clip_time`, tick for tick (`2215019520000` on both sides). The correction is a **verified** no-op, not merely a theoretical one.

**Scenario matrix** — all render correctly with the patch:

| Scenario | Evidence | Result |
|---|---|---|
| Master clip, trimmed on timeline | numeric + visual | unchanged — `media_time == clip_time` exactly; `ContentStart` absent, so the fix is inert |
| Subclip, untrimmed | numeric + visual | **fixed** — `clip_time=1.12s + 18.08 = 19.20s`, in-window |
| Subclip, further trimmed on timeline | visual | **fixed** — confirms the offset tracks the subclip origin, not the timeline in-point |
| Subclip @ 50% speed (`Media_ClipSpeed = 0.5`) | numeric + visual | **fixed** — `clip_time=1.86s + 18.08 = 19.94s`; window 19.94 – 22.16 s, in-window |
| Subclip with "use full clip extents" enabled | numeric + visual | correct — Premiere then reports **no** `ContentStart`, so the clip behaves as a master clip and the fix is inert. (This is the Premiere analogue of the "Use full clip extents" workaround from #25.) |
| Proxies attached, proxy toggle on and off | numeric + visual | unaffected — `Media_InstanceString` always resolves the full-res path; the proxy path only ever appears in `Media_ProxyInstanceString`, so project lookup and timing are unchanged |
| CUDA backend | numeric + visual | fixed |
| OpenCL backend | numeric + visual | fixed |

**Also checked and ruled out as causes** along the way, in case it saves anyone time: embedded gyro blob vs. external `.bin` staleness (core `lib.rs` prefers `gyro_source.file_metadata` when it decodes, so app and plugin read identical data); moved-media path mismatch; and per-clip stuck effect state (#22 — remove/re-add from the bin changed nothing).

## Known limitation: GPU filter path only

This fixes the **GPU filter path** (`premiere.rs`). Premiere also registers CPU pixel formats and can render this effect through the AE-style `smart_render` path in `lib.rs`, which derives its timestamp from `in_data.current_timestamp()` with no equivalent correction — **a subclip rendered through that path is still affected.**

I was not able to test that path, and want to be upfront about why rather than imply it doesn't matter:

- There is no longer a user-facing way to force it — ["Mercury Playback Engine Software Only" was removed from Project Settings in 25.2](https://helpx.adobe.com/premiere/desktop/troubleshooting/limitations-and-known-issues/software-rendering-update.html), and the Shift-launch fallback went shortly after.
- On my machine (26.2, working CUDA GPU) it never fired across ~6,700 instrumented renders — but that's a statement about my setup, not about the path being dead.

It clearly is still reachable for others: the [26.3 release notes](https://helpx.adobe.com/premiere/desktop/whats-new/release-notes.html) still speak of *"reducing the number of cases where the application unexpectedly falls back to software rendering"*, and per the SDK, [returning an error from `CreateInstance`](https://ppro-plugins.docsforadobe.dev/gpu-effects-transitions/function-descriptions/) routes a node to software for the current parameter set. So a user whose GPU isn't detected or supported would still see this on subclips.

(This is Premiere-specific — After Effects uses `smart_render` unconditionally, but has no bin-subclip concept, so `Media_ContentStart` doesn't apply there.)

If you'd like that path covered too, `VideoSegmentSuite` isn't reachable from it, but `ae::pf::suites::Utility` looks like the way in — `source_track_media_actual_start_time`, `clip_start`, `unscaled_clip_start` and `track_item_start` are all plausible sources for the same offset. I'd rather not guess which one without being able to verify it against real values the way I could here; happy to extend this PR if you can point me at a reliable way to hit the software path, or if you already know which of those carries the subclip origin.

## Two incidental findings in the same function

Not touched by this PR, but noticed while instrumenting:

1. `trim_range` (premiere.rs, ~line 153) is **dead code** — rustc emits `variable 'trim_range' is assigned to, but never used`. Its only consumer was commented out in fe6d951 ("Disable trim range from clip bounds in Premiere").
2. That same block calls `transform_node_time(clip_node, ...)` on values from `Media_InPointMediaTimeAsTicks`, which are already in media time. Per the suite docs `transform_node_time` converts *clip-node* time *into* media time, so this reads as inverted — with the patch's logging it produced a degenerate zero-length range `(7.34, 7.34)`. Harmless today since the value is discarded, but it would bite whoever re-enables that block.
