### PR TITLE
OpenFX: Add anamorphic squeeze ratio support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## [2.2.0] - 2026-08-09
+
+### Added
+
+- Added anamorphic input squeeze-ratio controls to the shared plugin parameter model used by the OpenFX and Adobe plugins.
+- Added preset ratios from `1.0x` through `2.0x`, plus a custom `1.0x`–`2.0x` slider.
+- Added the hidden `SqueezeBorder` metadata parameter, which publishes a centered source-pixel auto-crop guide as JSON.
+
+### Changed
+
+- Anamorphic mode preserves the raw image without applying lens-profile de-squeezing or changing the rendered output.
+- Active squeeze ratios use the full source dimensions for the internal fit and avoid zooming in; the published border is a guide for host integrations and does not crop the image by itself.

--- a/README-OpenFX.md
+++ b/README-OpenFX.md
@@ -31,6 +31,10 @@ Create the folder if it doesn't exist yet.
 
 # Usage
 
+## Anamorphic squeeze ratio
+
+Use **Input Squeeze ratio** in the plugin parameters to select a common anamorphic ratio or **Custom** for a value from `1.0x` to `2.0x`. In anamorphic mode, the plugin preserves the raw image and exposes the centered auto-crop region as JSON through the hidden `SqueezeBorder` parameter. This border is a guide for host integrations; it does not crop or de-squeeze the rendered image.
+
 ### Export `.gyroflow` file in the Gyroflow app
 
 Click the `Export project file (including gyro data)` in the Gyroflow app. You can also use `Ctrl+S` or `Command+S` shortcut

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ This exported project file is then loaded inside the Gyroflow plugin in the vide
 
 This is especially important when working with RAW files (like BRAW or R3D), where you retain all your RAW controls like ISO, White Balance etc.
 
+### Anamorphic squeeze ratio
+
+The OpenFX and Adobe plugins support anamorphic input through the **Input Squeeze ratio** control in the plugin parameters. Choose a preset ratio or select **Custom** and enter a value from `1.0x` to `2.0x`. The plugins keep the source image unchanged and publish the calculated centered auto-crop region through the hidden `SqueezeBorder` parameter for host integrations that can consume it; the border is a guide and does not itself crop or de-squeeze the rendered image.
+
 ---
 
 This repository contains the source code of [Gyroflow](https://github.com/gyroflow/gyroflow) video editor plugins. This includes OpenFX, Adobe and frei0r.<br>

--- a/adobe/Cargo.lock
+++ b/adobe/Cargo.lock
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "gyroflow_adobe"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "after-effects",
  "bincode",

--- a/adobe/Cargo.toml
+++ b/adobe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gyroflow_adobe"
-version = "2.1.1"
+version = "2.2.0"
 authors = ["Adrian <adrian.eddy@gmail.com>"]
 edition = "2024"
 

--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -1188,7 +1188,7 @@ version = "0.1.0"
 dependencies = [
  "fastrand",
  "gyroflow-core",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lazy_static",
  "log",
  "log-panics",
@@ -1465,6 +1465,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -24,6 +24,7 @@ pub enum Params {
     ProjectData,
     EmbeddedLensProfile,
     EmbeddedPreset,
+    SqueezeBorder,
     ProjectGroup, ProjectGroupEnd,
     LoadCurrent,
     ProjectPath,
@@ -49,6 +50,8 @@ pub enum Params {
     VideoSpeed,
     DisableStretch,
     IntegrationMethod,
+    SqueezeRatio,
+    CustomSqueezeRatio,
     KeyframesGroup, KeyframesGroupEnd,
     UseGyroflowsKeyframes,
     RecalculateKeyframes,
@@ -69,6 +72,10 @@ pub enum Params {
     Interpolation,
     FusionStartFrame,
 }
+
+/// Fixed anamorphic squeeze ratio options (index 10 = custom slider).
+pub const ANAMORPHIC_SQUEEZE_OPTIONS: [f64; 10] =
+    [1.0, 1.25, 1.3, 4.0 / 3.0, 1.5, 1.6, 1.7, 1.8, 1.85, 2.0];
 
 thread_local! {
     pub static LOG_INITIALIZED: Cell<bool> = Cell::new(false);
@@ -170,6 +177,19 @@ impl GyroflowPluginBase {
         }
     }
 
+    /// Resolve the current anamorphic squeeze ratio from the plugin params.
+    pub fn get_squeeze(params: &dyn GyroflowPluginParams) -> f64 {
+        match params.get_i32(Params::SqueezeRatio) {
+            Ok(idx) if idx >= 0 && (idx as usize) < ANAMORPHIC_SQUEEZE_OPTIONS.len() =>
+                ANAMORPHIC_SQUEEZE_OPTIONS[idx as usize],
+            Ok(10) => params
+                .get_f64(Params::CustomSqueezeRatio)
+                .unwrap_or(4.0 / 3.0)
+                .clamp(1.0, 2.0),
+            _ => 1.0,
+        }
+    }
+
     pub fn get_project_path(file_path: &str) -> Option<String> {
         let mut project_path = std::path::Path::new(file_path).with_extension("gyroflow");
         if !project_path.exists() {
@@ -261,13 +281,14 @@ impl GyroflowPluginBase {
         }
     }
 
-    pub fn get_param_definitions() -> [ParameterType; 13] {
+    pub fn get_param_definitions() -> [ParameterType; 14] {
         [
             ParameterType::HiddenString { id: "InstanceId" },
             ParameterType::HiddenString { id: "ProjectPath" },
             ParameterType::HiddenString { id: "ProjectData" },
             ParameterType::HiddenString { id: "EmbeddedLensProfile" },
             ParameterType::HiddenString { id: "EmbeddedPreset" },
+            ParameterType::HiddenString { id: "SqueezeBorder" },
             ParameterType::Group { id: "ProjectGroup", label: "Gyroflow project", opened: true, parameters: vec![
                 ParameterType::Text    { id: "Status",            label: "Status",                   hint: "Status" },
                 ParameterType::Button  { id: "LoadCurrent",       label: "Load for current file",    hint: "Try to load project file for current video file, or try to stabilize that video file directly" },
@@ -293,6 +314,8 @@ impl GyroflowPluginBase {
                 ParameterType::Slider   { id: "VideoSpeed",             label: "Video speed",          hint: "Use this slider to change video speed or keyframe it, instead of built-in speed changes in the editor", min: 0.0001, max: 1000.0, default: 100.0 },
                 ParameterType::Checkbox { id: "DisableStretch",         label: "Disable Gyroflow's stretch", hint: "If you used Input stretch in the lens profile in Gyroflow, and you de-stretched the video separately in your editor (by setting anamorphic squeeze factor), check this to disable Gyroflow's internal stretching.", default: false },
                 ParameterType::Select   { id: "IntegrationMethod",      label: "Integration method",   hint: "IMU integration method", options: vec!["None", "Complementary", "VQF", "Simple gyro", "Simple gyro + accel", "Mahony", "Madgwick"], default: "VQF" },
+                ParameterType::Select   { id: "SqueezeRatio",       label: "Input Squeeze ratio",       hint: "Anamorphic squeeze ratio of the lens. When greater than 1x it only publishes the auto-crop border guide (regionW = clipH * timelineAspect / squeeze, full height, centered) to the hidden SqueezeBorder parameter; it never changes the rendered output.", options: vec!["1.0x (Default)", "1.25x", "1.3x", "1.33x", "1.5x", "1.6x", "1.7x", "1.8x", "1.85x", "2x", "Custom"], default: "1.0x (Default)" },
+                ParameterType::Slider   { id: "CustomSqueezeRatio", label: "Custom squeeze ratio", hint: "Custom squeeze ratio (1.0x - 2.0x), used when Squeeze ratio is set to Custom", min: 1.0, max: 2.0, default: 1.3333 },
                 //ParameterType::Slider   { id: "FusionStartFrame",       label: "Fusion Start Frame",   hint: "Fusion Start Frame (from Project Settings)", min: 0.0, max: 100000.0, default: 0.0 },
             ] },
             ParameterType::Group { id: "KeyframesGroup", label: "Keyframes", opened: false, parameters: vec![
@@ -453,6 +476,10 @@ impl GyroflowPluginBaseInstance {
         let _ = params.set_enabled(Params::VideoSpeed, loaded);
         let _ = params.set_enabled(Params::DisableStretch, loaded);
         let _ = params.set_enabled(Params::IntegrationMethod, loaded);
+        // Squeeze framing controls work regardless of gyro loading; only the
+        // custom value is gated on the "Custom" selection.
+        let _ = params.set_enabled(Params::CustomSqueezeRatio,
+                                   params.get_i32(Params::SqueezeRatio).unwrap_or(0) == 10);
         let _ = params.set_enabled(Params::ToggleOverview, loaded);
         let _ = params.set_enabled(Params::ReloadProject, loaded);
         let _ = params.set_enabled(Params::OutputWidth, loaded);
@@ -461,6 +488,89 @@ impl GyroflowPluginBaseInstance {
         let _ = params.set_enabled(Params::OutputSizeSwap, loaded);
         let _ = params.set_string(Params::Status, if loaded { "OK" } else { "Project not loaded" });
         let _ = params.set_label(Params::OpenGyroflow, if loaded { "Open in Gyroflow" } else { "Open Gyroflow" });
+        self.update_squeeze_border(params);
+    }
+
+    /// Publish the squeeze-ratio border to the hidden `SqueezeBorder` param.
+    /// The border is a pure auto-crop guide: it describes the region of the
+    /// source that de-squeezes to the timeline aspect
+    /// (regionW = clipH * (timelineW / timelineH) / squeeze, capped at clipW,
+    /// full height, centered) and is published as JSON
+    /// `{"x", "y", "w", "h", "squeeze"}` in source pixels. It never changes
+    /// the rendered output.
+    pub fn update_squeeze_border(&self, params: &mut dyn GyroflowPluginParams) {
+        let squeeze = GyroflowPluginBase::get_squeeze(params);
+        let border = if squeeze > 1.001 {
+            let clip_w = self.original_video_size.0 as f64;
+            let clip_h = self.original_video_size.1 as f64;
+            let tl_w = self.timeline_size.0 as f64;
+            let tl_h = self.timeline_size.1 as f64;
+            if clip_w > 0.0 && clip_h > 0.0 && tl_w > 0.0 && tl_h > 0.0 {
+                let region_w = (clip_h * (tl_w / tl_h) / squeeze).min(clip_w);
+                Some(serde_json::json!({
+                    "x": (clip_w - region_w) / 2.0,
+                    "y": 0.0,
+                    "w": region_w,
+                    "h": clip_h,
+                    "squeeze": squeeze,
+                }))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        let value = border.map(|v| v.to_string()).unwrap_or_default();
+        // Idempotent write: update_loaded_state can be reached from the render
+        // path (via set_status), so avoid touching the param when unchanged.
+        if params.get_string(Params::SqueezeBorder).unwrap_or_default() != value {
+            let _ = params.set_string(Params::SqueezeBorder, &value);
+        }
+    }
+
+    /// Internal output size for the anamorphic workflow: when SqueezeRatio >
+    /// 1, the internal output size becomes the FULL source size (W x H) so
+    /// the render maps the entire clip at natural scale (never zooming in)
+    /// into the timeline canvas (the render's out_rect centers it). The
+    /// squeeze border (SqueezeBorder) is published as an auto-crop guide only;
+    /// it never frames or clips the output. Returns None at SqueezeRatio <= 1
+    /// (original timeline-fill behavior).
+    fn anamorphic_output_size(&self, params: &dyn GyroflowPluginParams) -> Option<(usize, usize)> {
+        if GyroflowPluginBase::get_squeeze(params) <= 1.001 {
+            return None;
+        }
+        let (clip_w, clip_h) = self.original_video_size;
+        if clip_w > 0 && clip_h > 0 {
+            Some((clip_w, clip_h))
+        } else {
+            None
+        }
+    }
+
+    /// Apply the anamorphic internal output size to every loaded manager and
+    /// refit the zoom. Called when SqueezeRatio / CustomSqueezeRatio /
+    /// OutputSizeToTimeline changes.
+    fn apply_squeeze_output_size(&mut self, params: &dyn GyroflowPluginParams) {
+        let squeeze = GyroflowPluginBase::get_squeeze(params);
+        let output = self.anamorphic_output_size(params);
+        for (_, v) in self.managers.iter_mut() {
+            v.params.write().squeeze_ratio = squeeze;
+            match output {
+                Some((bw, bh)) => {
+                    v.set_output_size(bw, bh);
+                }
+                None => {
+                    if let (Ok(ow), Ok(oh)) = (
+                        params.get_f64(Params::OutputWidth),
+                        params.get_f64(Params::OutputHeight),
+                    ) {
+                        v.set_output_size(ow as _, oh as _);
+                    }
+                }
+            }
+            v.invalidate_blocking_zooming();
+            v.invalidate_blocking_undistortion();
+        }
     }
 
     pub fn initialize_instance_id(&mut self, instance_id: &mut String) {
@@ -591,11 +701,21 @@ impl GyroflowPluginBaseInstance {
                 let filesize = file.size;
                 match stab.load_video_file(file.get_file(), filesize, &url, None, true) {
                     Ok(md) => {
-                        if out_size != (0, 0) {
-                            stab.params.write().output_size = out_size; // Default to timeline output size
-                        }
                         if let Some(preset_out_size) = stab.input_file.read().preset_output_size {
                             stab.params.write().output_size = preset_out_size;
+                        }
+                        // Keep the output at the TIMELINE resolution so the
+                        // host displays the frame 1:1 (a source-sized output
+                        // gets rescaled by the host to the timeline, which can
+                        // stretch anamorphic footage). The minimal-FOV fit is
+                        // patched in gyroflow-core to target the ORIGINAL clip
+                        // framing and cancel get_fov's width/output_width
+                        // factor, so the full source renders at natural scale
+                        // in the timeline canvas (letterbox bars filled with
+                        // the background). The squeeze-ratio border
+                        // (SqueezeBorder) remains the auto-crop guide.
+                        if out_size != (0, 0) {
+                            stab.params.write().output_size = out_size;
                         }
 
                         if let Ok(d) = params.get_string(Params::EmbeddedLensProfile) {
@@ -818,6 +938,21 @@ impl GyroflowPluginBaseInstance {
                 stab.disable_lens_stretch(self.anamorphic_adjust_size);
             }
 
+            // Anamorphic mode behavior: never de-squeeze the image.
+            // Gyroflow lens profiles can carry `input_horizontal_stretch` /
+            // `input_vertical_stretch` (anamorphic de-squeeze), which the core
+            // renderer applies as a horizontal stretch (`uv /= stretch`) and
+            // through the camera matrix scaling. The C plugin ignores these
+            // fields, so force them to 1.0 here to keep the raw image
+            // unchanged; the squeeze-ratio border (SqueezeBorder) is the
+            // auto-crop guide.
+            stab.set_input_horizontal_stretch(1.0);
+            stab.set_input_vertical_stretch(1.0);
+
+            // Anamorphic squeeze ratio drives the auto-zoom fit target
+            // (gyroflow-core calculate_fovs) and the published border.
+            stab.params.write().squeeze_ratio = GyroflowPluginBase::get_squeeze(params);
+
             stab.set_fov_overview(params.get_bool(Params::ToggleOverview)?);
 
             {
@@ -827,6 +962,17 @@ impl GyroflowPluginBaseInstance {
 
             stab.init_size();
             stab.set_output_size(params.get_f64(Params::OutputWidth)? as _, params.get_f64(Params::OutputHeight)? as _);
+            // Anamorphic mode: when the squeeze ratio is active, the
+            // internal output size becomes the FULL source size so the render
+            // maps the entire clip at natural scale into the timeline canvas
+            // (the host out_rect is set in the render path). The squeeze
+            // border (SqueezeBorder) is an auto-crop guide only and never
+            // frames/clips the output. The host ROD and OutputWidth-Height
+            // stay at the timeline resolution. The zoom stays at natural
+            // scale (fov_eff >= 1, never zooming in).
+            if let Some((bw, bh)) = self.anamorphic_output_size(params) {
+                stab.set_output_size(bw, bh);
+            }
 
             self.set_keyframe_provider(&stab);
 
@@ -943,6 +1089,18 @@ impl GyroflowPluginBaseInstance {
                 self.reload_values_from_project = true;
             }
             self.clear_stab(&manager_cache);
+        }
+        if param == Params::SqueezeRatio || param == Params::CustomSqueezeRatio || param == Params::OutputSizeToTimeline {
+            // Publish the auto-crop border guide (no de-squeeze or stretch is
+            // ever applied to the image; framing via the border is handled by
+            // the auto-zoom fit below).
+            let _ = params.set_enabled(Params::CustomSqueezeRatio,
+                                       params.get_i32(Params::SqueezeRatio).unwrap_or(0) == 10);
+            self.update_squeeze_border(params);
+        }
+        if param == Params::SqueezeRatio || param == Params::CustomSqueezeRatio || param == Params::OutputSizeToTimeline {
+            // Re-fit the internal output size (border vs timeline) and zoom.
+            self.apply_squeeze_output_size(params);
         }
         if param == Params::IncludeProjectData {
             let path = params.get_string(Params::ProjectPath)?;

--- a/frei0r/Cargo.lock
+++ b/frei0r/Cargo.lock
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "gyroflow-frei0r"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "cstr",
  "gyroflow-plugin-base",

--- a/frei0r/Cargo.toml
+++ b/frei0r/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gyroflow-frei0r"
-version = "2.1.1"
+version = "2.2.0"
 authors = ["Adrian <adrian.eddy@gmail.com>"]
 edition = "2021"
 description = "Gyroflow frei0r plugin"

--- a/openfx/Cargo.lock
+++ b/openfx/Cargo.lock
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "gyroflow-ofx"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "gyroflow-plugin-base",
  "log",

--- a/openfx/Cargo.toml
+++ b/openfx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gyroflow-ofx"
-version = "2.1.1"
+version = "2.2.0"
 authors = ["Adrian <adrian.eddy@gmail.com>", "Ilya Epifanov <elijah.epifanov@gmail.com>"]
 license = "GPL-3.0-or-later"
 edition = "2024"

--- a/openfx/src/gyroflow.rs
+++ b/openfx/src/gyroflow.rs
@@ -34,6 +34,7 @@ define_params!(ParamHandler {
         ProjectData         => project_data:     ParamHandle<String>,
         EmbeddedLensProfile => embedded_lens:    ParamHandle<String>,
         EmbeddedPreset      => embedded_preset:  ParamHandle<String>,
+        SqueezeBorder       => squeeze_border:   ParamHandle<String>,
         ProjectPath         => project_path:     ParamHandle<String>,
         OpenGyroflow        => open_in_gyroflow: ParamHandle<String>,
         ReloadProject       => reload_project:   ParamHandle<String>,
@@ -66,11 +67,13 @@ define_params!(ParamHandler {
         VideoSpeed            => video_speed:              ParamHandle<Double>,
         OutputWidth           => output_width:             ParamHandle<Double>,
         OutputHeight          => output_height:            ParamHandle<Double>,
+        CustomSqueezeRatio    => custom_squeeze_ratio:     ParamHandle<Double>,
         //FusionStartFrame      => fusion_start_frame:       ParamHandle<Double>,
     ],
     i32s: [
         Interpolation         => interpolation:            ParamHandle<Int>,
         IntegrationMethod     => integration_method:       ParamHandle<Int>,
+        SqueezeRatio          => squeeze_ratio:            ParamHandle<Int>,
     ],
 
     get_string:  _s p    { Ok(p.get_value()?) },
@@ -279,7 +282,30 @@ impl Execute for GyroflowPlugin {
 
                 let src_rect = GyroflowPluginBase::get_center_rect(src_size.0, src_size.1, org_ratio);
 
-                let mut out_rect = if instance_data.params.get_bool_at_time(Params::DontDrawOutside, TimeType::Frame(time)).unwrap() { // TODO: unwrap
+                // When the squeeze ratio is active, the
+                // internal output size is the FULL source size and this
+                // out_rect maps the timeline buffer's centered source region
+                // onto it 1:1, so the entire stabilized clip is shown at
+                // natural scale (never zooming in) with the area outside the
+                // source as background. The squeeze border (SqueezeBorder) is
+                // an auto-crop guide only and never frames the output.
+                let squeeze = GyroflowPluginBase::get_squeeze(&instance_data.params);
+                let mut out_rect = if squeeze > 1.001 {
+                    let clip_w = src_rect.2 as f64;
+                    let clip_h = src_rect.3 as f64;
+                    let out_w = out_size.0 as f64;
+                    let h = (clip_h as usize).min(out_size.1);
+                    if out_w > clip_w {
+                        Some((
+                            ((out_w - clip_w) / 2.0).round() as usize,
+                            0,
+                            clip_w.round() as usize,
+                            h,
+                        ))
+                    } else {
+                        None
+                    }
+                } else if instance_data.params.get_bool_at_time(Params::DontDrawOutside, TimeType::Frame(time)).unwrap() { // TODO: unwrap
                     let output_ratio = out_size.0 as f64 / out_size.1 as f64;
                     let mut rect = GyroflowPluginBase::get_center_rect(src_rect.2, src_rect.3, output_ratio);
                     rect.0 += src_rect.0;
@@ -435,6 +461,7 @@ impl Execute for GyroflowPlugin {
                         project_data:             param_set.parameter("ProjectData")?,
                         embedded_lens:            param_set.parameter("EmbeddedLensProfile")?,
                         embedded_preset:          param_set.parameter("EmbeddedPreset")?,
+                        squeeze_border:           param_set.parameter("SqueezeBorder")?,
                         project_path:             param_set.parameter("ProjectPath")?,
                         disable_stretch:          param_set.parameter("DisableStretch")?,
                         status:                   param_set.parameter("Status")?,
@@ -463,6 +490,8 @@ impl Execute for GyroflowPlugin {
                         output_size_fit:          param_set.parameter("OutputSizeToTimeline")?,
                         interpolation:            param_set.parameter("Interpolation")?,
                         integration_method:       param_set.parameter("IntegrationMethod")?,
+                        squeeze_ratio:            param_set.parameter("SqueezeRatio")?,
+                        custom_squeeze_ratio:     param_set.parameter("CustomSqueezeRatio")?,
 
                         loaded_project:           param_set.parameter("LoadedProject")?,
                         loaded_lens:              param_set.parameter("LoadedLens")?,


### PR DESCRIPTION
Add configurable anamorphic squeeze ratios for OpenFX and Adobe plugins.

- Add preset and custom squeeze-ratio parameters
- Publish the calculated crop guide through SqueezeBorder
- Preserve raw rendering without de-squeezing
- Adjust anamorphic output fitting to avoid unwanted zoom
- Update version metadata to 2.2.0
- Document the new workflow and add release notes