### PR TITLE
Add Shotcut support and fix Gyroflow frei0r project handling

### DIFF
--- a/frei0r/src/lib.rs
+++ b/frei0r/src/lib.rs
@@ -21,6 +21,7 @@ struct Instance {
     smoothness: f64,
     stab_overview: bool,
     time_scale: f64,
+    time_offset: f64,
 }
 
 #[no_mangle] extern "C" fn f0r_init() -> ::std::os::raw::c_int { 1 }
@@ -36,7 +37,7 @@ extern "C" fn f0r_get_plugin_info(info: *mut f0r_plugin_info) {
         (*info).frei0r_version = FREI0R_MAJOR_VERSION;
         (*info).major_version = 0;
         (*info).minor_version = 1;
-        (*info).num_params = 4;
+        (*info).num_params = 5;
         (*info).explanation = cstr!("Gyroflow video stabilization").as_ptr();
     }
 }
@@ -63,6 +64,11 @@ extern "C" fn f0r_get_param_info(info: *mut f0r_param_info, index: ::std::os::ra
                 (*info).name = cstr!("TimestampScale").as_ptr();
                 (*info).type_ = F0R_PARAM_DOUBLE;
                 (*info).explanation = cstr!("Scale for the input timestamp").as_ptr();
+            },
+            4 => {
+                (*info).name = cstr!("TimestampOffset").as_ptr();
+                (*info).type_ = F0R_PARAM_DOUBLE;
+                (*info).explanation = cstr!("Offset for the input timestamp in seconds").as_ptr();
             }
             _ => { }
         }
@@ -152,6 +158,9 @@ extern "C" fn f0r_set_param_value(instance: f0r_instance_t, param: f0r_param_t, 
             3 => { // Timestamp scale
                 inst.time_scale = *(param as *mut f64);
             },
+            4 => { // Timestamp offset
+                inst.time_offset = *(param as *mut f64);
+            },
             _ => { }
         }
     }
@@ -176,6 +185,9 @@ extern "C" fn f0r_get_param_value(instance: f0r_instance_t, param: f0r_param_t, 
             3 => { // Timestamp scale
                 *(param as *mut f64) = inst.time_scale;
             },
+            4 => { // Timestamp offset
+                *(param as *mut f64) = inst.time_offset;
+            },
             _ => { }
         }
     }
@@ -187,7 +199,7 @@ extern "C" fn f0r_update(instance: f0r_instance_t, time: f64, inframe: *const u3
     if instance.is_null() { return; }
     let inst = unsafe { Box::from_raw(instance as *mut Instance) };
 
-    let timestamp_us = (time * 1_000_000.0 * inst.time_scale).round() as i64;
+    let timestamp_us = ((time * inst.time_scale + inst.time_offset) * 1_000_000.0).round() as i64;
 
     let org_ratio = {
         let params = inst.stab.params.read();

--- a/frei0r/src/lib.rs
+++ b/frei0r/src/lib.rs
@@ -112,6 +112,10 @@ extern "C" fn f0r_set_param_value(instance: f0r_instance_t, param: f0r_param_t, 
                     } else {
                         if let Err(e) = inst.stab.import_gyroflow_file(&filesystem::path_to_url(&path), true, |_|(), Arc::new(AtomicBool::new(false)), true) {
                             log::error!("import_gyroflow_file error: {e:?}");
+                        } else {
+                            // Project gyro transforms (including LPF) are restored after the
+                            // embedded motion data is loaded, so apply them before smoothing.
+                            inst.stab.recompute_gyro();
                         }
                     }
 

--- a/shotcut/gyroflow/meta.qml
+++ b/shotcut/gyroflow/meta.qml
@@ -1,0 +1,13 @@
+import QtQuick
+import org.shotcut.qml
+
+Metadata {
+    type: Metadata.Filter
+    name: qsTr("Gyroflow")
+    keywords: qsTr("stabilization smooth shake action camera gyro") + " gyroflow #rgba"
+    mlt_service: "frei0r.gyroflow"
+    objectName: "gyroflow"
+    qml: "ui.qml"
+    isClipOnly: true
+    allowMultiple: false
+}

--- a/shotcut/gyroflow/ui.qml
+++ b/shotcut/gyroflow/ui.qml
@@ -17,6 +17,16 @@ Item {
     property bool defaultOverview: false
     property real defaultTimestampScale: 1.0
     property bool blockUpdate: true
+    property string sourceResource: ""
+
+    function syncToClipIn() {
+        var inFrame = producer.in;
+        Qt.callLater(function() {
+            if ((producer.resource || "") === sourceResource &&
+                    producer.in === inFrame && profile.fps > 0)
+                filter.set("TimestampOffset", inFrame / profile.fps);
+        });
+    }
 
     function inferredProjectPath() {
         var resource = producer.resource || "";
@@ -41,9 +51,10 @@ Item {
     }
 
     width: 360
-    height: 250
+    height: 210
 
     Component.onCompleted: {
+        sourceResource = producer.resource || "";
         defaultProjectPath = inferredProjectPath();
         if (filter.isNew) {
             filter.set("Project", defaultProjectPath);
@@ -52,6 +63,7 @@ Item {
             filter.set("TimestampScale", defaultTimestampScale);
         }
         setControls();
+        syncToClipIn();
     }
 
     Shotcut.File {
@@ -166,12 +178,6 @@ Item {
             onClicked: timestampScale.value = defaultTimestampScale
         }
 
-        Shotcut.TipBox {
-            Layout.columnSpan: 3
-            Layout.fillWidth: true
-            text: qsTr("First save a project containing gyro data from Gyroflow. Shotcut currently restarts frei0r time after changing a clip's In point, so trimming or splitting can desynchronize stabilization. Use an untrimmed clip or a stabilized intermediate.")
-        }
-
         Item { Layout.fillHeight: true }
     }
 
@@ -180,4 +186,10 @@ Item {
         function onChanged() { setControls(); }
         function onPropertyChanged(name) { setControls(); }
     }
+
+    Connections {
+        target: producer
+        function onInChanged() { root.syncToClipIn(); }
+    }
+
 }

--- a/shotcut/gyroflow/ui.qml
+++ b/shotcut/gyroflow/ui.qml
@@ -1,0 +1,183 @@
+/*
+ * Shotcut frontend for the Gyroflow frei0r plugin.
+ * Derived from Gyroflow's Kdenlive metadata and the Shotcut forum prototype.
+ */
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Dialogs
+import QtQuick.Layouts
+import Shotcut.Controls as Shotcut
+import org.shotcut.qml as Shotcut
+
+Item {
+    id: root
+
+    property string defaultProjectPath: ""
+    property real defaultSmoothness: 0.5
+    property bool defaultOverview: false
+    property real defaultTimestampScale: 1.0
+    property bool blockUpdate: true
+
+    function inferredProjectPath() {
+        var resource = producer.resource || "";
+        var query = resource.indexOf("?");
+        if (query >= 0)
+            resource = resource.substring(0, query);
+        var slash = Math.max(resource.lastIndexOf("/"), resource.lastIndexOf("\\"));
+        var dot = resource.lastIndexOf(".");
+        if (dot > slash)
+            resource = resource.substring(0, dot);
+        return resource + ".gyroflow";
+    }
+
+    function setControls() {
+        blockUpdate = true;
+        projectFile.url = filter.get("Project");
+        smoothness.value = filter.getDouble("Smoothness");
+        overview.checked = filter.get("Overview") === "1";
+        var scale = filter.getDouble("TimestampScale");
+        timestampScale.value = scale > 0 ? scale : defaultTimestampScale;
+        blockUpdate = false;
+    }
+
+    width: 360
+    height: 250
+
+    Component.onCompleted: {
+        defaultProjectPath = inferredProjectPath();
+        if (filter.isNew) {
+            filter.set("Project", defaultProjectPath);
+            filter.set("Smoothness", defaultSmoothness);
+            filter.set("Overview", defaultOverview ? 1 : 0);
+            filter.set("TimestampScale", defaultTimestampScale);
+        }
+        setControls();
+    }
+
+    Shotcut.File {
+        id: projectFile
+
+        onUrlChanged: {
+            projectLabel.text = fileName || qsTr("No project selected");
+            projectTip.text = filePath || qsTr("Select a .gyroflow project file");
+            projectLabel.color = fileName.length > 0 && exists() ? activePalette.text : "red";
+            if (!blockUpdate)
+                filter.set("Project", filePath);
+        }
+    }
+
+    Shotcut.FileDialog {
+        id: projectDialog
+        title: qsTr("Select Gyroflow project file")
+        nameFilters: [qsTr("Gyroflow project (*.gyroflow)"), qsTr("All files (*)")]
+        onAccepted: projectFile.url = selectedFile
+    }
+
+    GridLayout {
+        columns: 3
+        anchors.fill: parent
+        anchors.margins: 8
+
+        Shotcut.Button {
+            text: qsTr("Open project")
+            onClicked: {
+                settings.openPath = producer.resource;
+                projectDialog.open();
+            }
+        }
+
+        Label {
+            id: projectLabel
+            Layout.fillWidth: true
+            elide: Text.ElideMiddle
+            Shotcut.HoverTip { id: projectTip }
+        }
+
+        Shotcut.UndoButton {
+            onClicked: projectFile.url = defaultProjectPath
+        }
+
+        Label {
+            text: qsTr("Smoothness")
+            Layout.alignment: Qt.AlignRight
+        }
+
+        Shotcut.SliderSpinner {
+            id: smoothness
+            Layout.fillWidth: true
+            minimumValue: 0
+            maximumValue: 1
+            stepSize: 0.01
+            decimals: 2
+            onValueChanged: {
+                if (!blockUpdate)
+                    filter.set("Smoothness", value);
+            }
+        }
+
+        Shotcut.UndoButton {
+            onClicked: smoothness.value = defaultSmoothness
+        }
+
+        Label {
+            text: qsTr("Overview")
+            Layout.alignment: Qt.AlignRight
+            Shotcut.HoverTip {
+                text: qsTr("Show the complete source area around the stabilized frame.")
+            }
+        }
+
+        CheckBox {
+            id: overview
+            leftPadding: 0
+            onClicked: filter.set("Overview", checked ? 1 : 0)
+        }
+
+        Shotcut.UndoButton {
+            onClicked: {
+                overview.checked = defaultOverview;
+                filter.set("Overview", defaultOverview ? 1 : 0);
+            }
+        }
+
+        Label {
+            text: qsTr("Time scale")
+            Layout.alignment: Qt.AlignRight
+            Shotcut.HoverTip {
+                text: qsTr("Scale Gyroflow timestamps for footage whose playback speed has changed.")
+            }
+        }
+
+        Shotcut.SliderSpinner {
+            id: timestampScale
+            Layout.fillWidth: true
+            minimumValue: 0.01
+            maximumValue: 10
+            stepSize: 0.01
+            decimals: 2
+            suffix: "x"
+            onValueChanged: {
+                if (!blockUpdate)
+                    filter.set("TimestampScale", value);
+            }
+        }
+
+        Shotcut.UndoButton {
+            onClicked: timestampScale.value = defaultTimestampScale
+        }
+
+        Shotcut.TipBox {
+            Layout.columnSpan: 3
+            Layout.fillWidth: true
+            text: qsTr("First save a project containing gyro data from Gyroflow. Shotcut currently restarts frei0r time after changing a clip's In point, so trimming or splitting can desynchronize stabilization. Use an untrimmed clip or a stabilized intermediate.")
+        }
+
+        Item { Layout.fillHeight: true }
+    }
+
+    Connections {
+        target: filter
+        function onChanged() { setControls(); }
+        function onPropertyChanged(name) { setControls(); }
+    }
+}


### PR DESCRIPTION
Add a Shotcut UI for the Gyroflow frei0r plugin.

Also:

- Apply project gyro transforms such as low-pass filtering.
- Keep stabilization synchronized when clips are trimmed or split.
- Avoid re-entrant updates that previously caused export crashes.

Tested with trimmed and split clips during preview and export.